### PR TITLE
feat: Add role selection to signup form

### DIFF
--- a/api/authentication/serializers.py
+++ b/api/authentication/serializers.py
@@ -6,10 +6,11 @@ class RegisterSerializer(serializers.ModelSerializer):
     password2 = serializers.CharField(style={'input_type': 'password'}, write_only=True)
     full_name = serializers.CharField(write_only=True)
     department = serializers.CharField(write_only=True)
+    role = serializers.CharField(write_only=True)
 
     class Meta:
         model = User
-        fields = ('username', 'email', 'password', 'password2', 'full_name', 'department')
+        fields = ('username', 'email', 'password', 'password2', 'full_name', 'department', 'role')
         extra_kwargs = {
             'password': {'write_only': True}
         }
@@ -22,6 +23,7 @@ class RegisterSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         full_name = validated_data.pop('full_name')
         department_name = validated_data.pop('department')
+        role = validated_data.pop('role')
         validated_data.pop('password2')
 
         # Split full_name into first_name and last_name
@@ -35,11 +37,15 @@ class RegisterSerializer(serializers.ModelSerializer):
             last_name=last_name if last_name else ''
         )
 
+        if role in ['Admin', 'HR']:
+            user.is_staff = True
+            user.save()
+
         # Get or create the department
         department, created = Department.objects.get_or_create(name=department_name)
 
         # Create the employee profile
-        Employee.objects.create(user=user, department=department)
+        Employee.objects.create(user=user, department=department, role=role)
         
         return user
 

--- a/frontend/src/pages/SignUpPage.jsx
+++ b/frontend/src/pages/SignUpPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
 import api from '../services/api';
-import { Container, Paper, TextField, Button, Typography, Box, Link } from '@mui/material';
+import { Container, Paper, TextField, Button, Typography, Box, Link, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 
 const SignUpPage = () => {
   const [username, setUsername] = useState('');
@@ -10,6 +10,7 @@ const SignUpPage = () => {
   const [password2, setPassword2] = useState('');
   const [fullName, setFullName] = useState('');
   const [department, setDepartment] = useState('');
+  const [role, setRole] = useState('Employee');
   const [error, setError] = useState('');
   const navigate = useNavigate();
 
@@ -28,6 +29,7 @@ const SignUpPage = () => {
         password2,
         full_name: fullName,
         department,
+        role,
       });
       navigate('/login');
     } catch (err) {
@@ -87,6 +89,20 @@ const SignUpPage = () => {
             value={department}
             onChange={(e) => setDepartment(e.target.value)}
           />
+          <FormControl fullWidth margin="normal">
+            <InputLabel id="role-select-label">Role</InputLabel>
+            <Select
+              labelId="role-select-label"
+              id="role"
+              value={role}
+              label="Role"
+              onChange={(e) => setRole(e.target.value)}
+            >
+              <MenuItem value="Employee">Employee</MenuItem>
+              <MenuItem value="HR">Employer</MenuItem>
+              <MenuItem value="Admin">Admin</MenuItem>
+            </Select>
+          </FormControl>
           <TextField
             margin="normal"
             required


### PR DESCRIPTION
- Updated the backend `RegisterSerializer` to handle a `role` field during registration.
- The serializer now sets the `is_staff` flag to `True` for 'Admin' and 'HR' roles.
- Modified the frontend `SignUpPage` to include a dropdown menu for role selection.
- Verified that the backend permissions align with the new role-based access control.