### PR TITLE
Fix 401 Unauthorized error by updating Django settings

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-y+og*(%&04il%#&rhcp7%mdlgo7m=@odh_okk*q-gf#w__r2t@
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 
 
 # Application definition
@@ -143,4 +143,6 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+]


### PR DESCRIPTION
This change aims to fix a 401 Unauthorized error by updating the Django settings for `ALLOWED_HOSTS` and CORS.

The `ALLOWED_HOSTS` setting was updated to explicitly allow 'localhost' and '127.0.0.1'.

The CORS settings were updated to be more specific, allowing only 'http://localhost:3000' and removing `CORS_ORIGIN_ALLOW_ALL`.