### PR TITLE
Add debugging for token generation

### DIFF
--- a/api/authentication/views.py
+++ b/api/authentication/views.py
@@ -19,12 +19,9 @@ class RegisterView(generics.CreateAPIView):
         
         # Create token for the new user
         token, created = Token.objects.get_or_create(user=user)
+        print(f"Token created for new user '{user.username}': {token.key}")
         
-        return Response({
-            'message': 'User created successfully',
-            'token': token.key,
-            'user': UserSerializer(user).data
-        }, status=status.HTTP_201_CREATED)
+        return Response({'token': token.key}, status=status.HTTP_201_CREATED)
 
 class LoginView(APIView):
     def post(self, request):
@@ -39,10 +36,8 @@ class LoginView(APIView):
         user = authenticate(username=username, password=password)
         if user:
             token, created = Token.objects.get_or_create(user=user)
-            return Response({
-                'token': token.key,
-                'user': UserSerializer(user).data
-            }, status=status.HTTP_200_OK)
+            print(f"Token created for user '{user.username}': {token.key}")
+            return Response({'token': token.key}, status=status.HTTP_200_OK)
         
         return Response({
             'error': 'Invalid credentials'


### PR DESCRIPTION
This commit adds `print` statements and simplifies the API responses for the login and register views. This is for debugging the 401 Unauthorized error.

These changes are not intended for production and should be reverted after the issue is resolved.